### PR TITLE
Spec refinements and version

### DIFF
--- a/office_docs.gemspec
+++ b/office_docs.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name        = "office_docs"
-  spec.version     = "0.5.0"
+  spec.version     = "0.5.2"
   spec.date        = "2015-12-01"
   spec.summary     = "Manipulate Microsoft Office Open XML files"
   spec.description = "Generate and modify Word .docx and Excel .xlsx files"

--- a/spec/cell_spec.rb
+++ b/spec/cell_spec.rb
@@ -1,4 +1,5 @@
 require_relative 'spec_helper'
+require_relative 'version_compatibility'
 
 require 'nokogiri'
 require 'date'
@@ -7,27 +8,9 @@ require_relative '../lib/office/excel/cell.rb'
 require_relative '../lib/office/excel.rb'
 require_relative '../lib/office/nokogiri_extensions.rb'
 
-# monkeypatches for RUBY_VERSION
-if RUBY_VERSION < '2.7.0'
-  class Time
-    def floor
-      Time.new(year, month, day, hour, min, sec.floor, utc_offset)
-    end
-  end
-end
-
-if RUBY_VERSION < '2.5.0'
-  class Hash
-    def transform_keys &blk
-      return enum_for __method__ unless block_given?
-      each_with_object Hash.new do |(key,value),ha|
-        ha[blk[key]] = value
-      end
-    end
-  end
-end
-
 describe Office::Cell do
+  using VersionCompatibility
+
   # Need a bunch of mockup xml stuff here because it's PITA to have a whole
   # workbook just to test cell functionality
   class MockXfStyle

--- a/spec/excel_workbooks_spec.rb
+++ b/spec/excel_workbooks_spec.rb
@@ -1,4 +1,5 @@
 require_relative 'spec_helper'
+require_relative 'version_compatibility'
 
 require 'csv'
 require 'office_docs'
@@ -6,6 +7,7 @@ require 'office_docs'
 # copy of the minitest test cases, because specs are easier to zero in on
 describe Office::ExcelWorkbook do
   include ReloadWorkbook
+  using VersionCompatibility
 
   it :test_parse_simple_workbook do
     Office::ExcelWorkbook.new(BookFiles::SIMPLE_TEST)

--- a/spec/version_compatibility.rb
+++ b/spec/version_compatibility.rb
@@ -1,0 +1,21 @@
+module VersionCompatibility
+  if RUBY_VERSION < '2.7.0'
+    refine Time do
+      def floor
+        Time.new(year, month, day, hour, min, sec.floor, utc_offset)
+      end
+    end
+  end
+
+  if RUBY_VERSION < '2.5.0'
+    refine Hash do
+      def transform_keys &blk
+        return enum_for __method__ unless block_given?
+        each_with_object Hash.new do |(key,value),ha|
+          ha[blk[key]] = value
+        end
+      end
+    end
+  end
+end
+


### PR DESCRIPTION
- Use refinement in specs to better expose version compatibilty issues.
- Bump gem version.
